### PR TITLE
Corrige o uso do *ngFor (F maiúsculo) e a variável heroi para heroi2 (conflito com variável já existente)

### DIFF
--- a/src/app/herois/herois.component.html
+++ b/src/app/herois/herois.component.html
@@ -10,6 +10,6 @@
 <h2> Meus Herois</h2>
 <ul class= "herois">
     <li
-        *ngfor="let heroi of herois">
+        *ngFor="let heroi2 of herois">
     </li>
 </ul>


### PR DESCRIPTION
Elias, segue a correção. Um erro muito básico, de falta de atenção, aonde o *ngFor tem um F maiúsculo e não minúsculo, isso fez a diferença. Assim que você aceitar esse "pull request", basta dar um "git pull" no seu projeto local para obter essa alteração. Abraços.